### PR TITLE
Enhance plants retrieve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official OpenJDK runtime as a parent image
-FROM openjdk:24-jdk-bullseye
+FROM openjdk:24-ea-jdk-bullseye
 
 RUN <<EOF
     apt-get -y update
@@ -23,6 +23,9 @@ COPY greenhouse_api.jar /app/greenhouse_api.jar
 
 # Copy the smol folder
 COPY src/main/resources/SMOL /app/SMOL
+
+COPY config_local.yml /app/config_local.yml
+COPY src/main/resources/watering-strategies.yml /app/watering-strategies.yml
 
 # Expose the port that the application will run on
 EXPOSE 8090

--- a/src/main/kotlin/org/smolang/greenhouse/api/config/ComponentsConfig.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/config/ComponentsConfig.kt
@@ -115,6 +115,10 @@ open class ComponentsConfig {
         plantCache.clear()
     }
 
+    open fun clearPumpCache() {
+        pumpCache.clear()
+    }
+
     open fun getPotCache(): PotCache {
         return potCache
     }

--- a/src/main/kotlin/org/smolang/greenhouse/api/controller/PlantController.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/controller/PlantController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.smolang.greenhouse.api.config.ComponentsConfig
 import org.smolang.greenhouse.api.config.REPLConfig
 import org.smolang.greenhouse.api.model.Plant
 import org.smolang.greenhouse.api.service.PlantService
@@ -23,7 +24,8 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBod
 class PlantController(
     private val replConfig: REPLConfig,
     private val plantService: PlantService,
-    private val potService: PotService
+    private val potService: PotService,
+    private val componentsConfig: ComponentsConfig
 ) {
 
     private val log: Logger = LoggerFactory.getLogger(PlantController::class.java.name)
@@ -152,6 +154,7 @@ class PlantController(
 
         log.info("Plant updated")
         replConfig.regenerateSingleModel().invoke("plants")
+        componentsConfig.removePlantFromCache(plantId)
         val updatedPlant = plantService.getPlantByPlantId(plantId) ?: return ResponseEntity.notFound().build()
 
         return ResponseEntity.ok(updatedPlant)
@@ -174,6 +177,9 @@ class PlantController(
         log.info("Updating a plant model")
 
         replConfig.reclassifySingleModel().invoke("plants")
+
+        // Clear the plant cache if applicable
+        componentsConfig.clearPlantCache()
 
         return ResponseEntity.ok("Plant model updated")
     }

--- a/src/main/kotlin/org/smolang/greenhouse/api/controller/PlantController.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/controller/PlantController.kt
@@ -157,6 +157,27 @@ class PlantController(
         return ResponseEntity.ok(updatedPlant)
     }
 
+    @Operation(summary = "Update the plant model")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Successfully updated the plant model"),
+            ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            ApiResponse(
+                responseCode = "403",
+                description = "Accessing the resource you were trying to reach is forbidden"
+            ),
+            ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
+        ]
+    )
+    @PatchMapping(produces = ["application/json"])
+    fun updatePlantModel(): ResponseEntity<String> {
+        log.info("Updating a plant model")
+
+        replConfig.reclassifySingleModel().invoke("plants")
+
+        return ResponseEntity.ok("Plant model updated")
+    }
+
     @Operation(summary = "Delete a plant")
     @ApiResponses(
         value = [

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
@@ -60,8 +60,8 @@ class PlantService(
     fun getAllPlants(): List<Plant>? {
         logger.debug("getAllPlants: retrieving all plants")
         // Return cached plants if available
-        val cached = componentsConfig.getPlantCache()
-        if (cached.isNotEmpty()) return cached.values.toList()
+//        val cached = componentsConfig.getPlantCache()
+//        if (cached.isNotEmpty()) return cached.values.toList()
         val plants =
             """
              SELECT ?plantId ?familyName ?potId ?moisture ?healthState ?status ?moistureState WHERE {
@@ -212,7 +212,7 @@ class PlantService(
     fun getPlantByPlantId(plantId: String): Plant? {
         logger.debug("getPlantByPlantId: retrieving plant $plantId")
         // Return cached plant if present
-        componentsConfig.getPlantById(plantId)?.let { return it }
+//        componentsConfig.getPlantById(plantId)?.let { return it }
         val query = """
             SELECT DISTINCT ?familyName ?potId ?moisture ?healthState ?status ?moistureState WHERE {
                 {

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
@@ -69,41 +69,97 @@ class PlantService(
                     ?obj a prog:Plant ;
                         prog:Plant_plantId ?plantId ;
                         prog:Plant_familyNameOut ?familyName ;
+                        prog:Plant_healthState ?hs ;
                         prog:Plant_pot ?pot ;
                         prog:Plant_moistureOut ?moisture .
-                    OPTIONAL { ?obj prog:Plant_healthState ?healthState }
                     OPTIONAL { ?obj prog:Plant_statusOut ?status }
                     BIND("unknown" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?obj a prog:ThirstyPlant ;
                         prog:ThirstyPlant_plantId ?plantId ;
                         prog:ThirstyPlant_familyNameOut ?familyName ;
+                        prog:ThirstyPlant_healthState ?hs ;
                         prog:ThirstyPlant_pot ?pot ;
                         prog:ThirstyPlant_moistureOut ?moisture .
-                    OPTIONAL { ?obj prog:ThirstyPlant_healthState ?healthState }
                     OPTIONAL { ?obj prog:ThirstyPlant_statusOut ?status }
                     BIND("thirsty" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?obj a prog:MoistPlant ;
                         prog:MoistPlant_plantId ?plantId ;
                         prog:MoistPlant_familyNameOut ?familyName ;
+                        prog:MoistPlant_healthState ?hs ;
                         prog:MoistPlant_pot ?pot ;
                         prog:MoistPlant_moistureOut ?moisture .
-                    OPTIONAL { ?obj prog:MoistPlant_healthState ?healthState }
                     OPTIONAL { ?obj prog:MoistPlant_statusOut ?status }
                     BIND("moist" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?obj a prog:OverwateredPlant ;
                         prog:OverwateredPlant_plantId ?plantId ;
                         prog:OverwateredPlant_familyNameOut ?familyName ;
+                        prog:OverwateredPlant_healthState ?hs ;
                         prog:OverwateredPlant_pot ?pot ;
                         prog:OverwateredPlant_moistureOut ?moisture .
-                    OPTIONAL { ?obj prog:OverwateredPlant_healthState ?healthState }
                     OPTIONAL { ?obj prog:OverwateredPlant_statusOut ?status }
                     BIND("overwatered" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 
                 ?pot a prog:Pot ;
@@ -128,11 +184,12 @@ class PlantService(
             val moisture = if (solution.contains("?moisture")) solution.get("?moisture").asLiteral().toString()
                 .split("^^")[0].toDouble() else null
 //            val healthState = if (solution.contains("?healthState")) solution.get("?healthState").asLiteral().toString() else null
-            val healthState = null
+            val healthState = solution.get("?healthState")?.asLiteral()?.toString()
             val status = if (solution.contains("?status")) solution.get("?status").asLiteral().toString() else null
             val retrievedState = solution.get("?moistureState").asLiteral().toString()
+            logger.info("Moisture state retrieved: $retrievedState")
             val moistureState = when (retrievedState) {
-                "thirst" -> PlantMoistureState.THIRSTY
+                "thirsty" -> PlantMoistureState.THIRSTY
                 "moist" -> PlantMoistureState.MOIST
                 "overwatered" -> PlantMoistureState.OVERWATERED
                 else -> PlantMoistureState.UNKNOWN
@@ -162,41 +219,97 @@ class PlantService(
                     ?plant a prog:Plant ;
                         prog:Plant_plantId "$plantId" ;
                         prog:Plant_familyName ?familyName ;
+                        prog:Plant_healthState ?hs ;
                         prog:Plant_pot ?pot ;
                         prog:Plant_moisture ?moisture .
-                    OPTIONAL { ?plant prog:Plant_healthState ?healthState }
                     OPTIONAL { ?plant prog:Plant_status ?status }
                     BIND("unknown" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?plant a prog:ThirstyPlant ;
                         prog:ThirstyPlant_plantId "$plantId" ;
                         prog:ThirstyPlant_familyName ?familyName ;
+                        prog:ThirstyPlant_healthState ?hs ;
                         prog:ThirstyPlant_pot ?pot ;
                         prog:ThirstyPlant_moisture ?moisture .
-                    OPTIONAL { ?plant prog:ThirstyPlant_healthState ?healthState }
                     OPTIONAL { ?plant prog:ThirstyPlant_status ?status }
                     BIND("thirsty" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?plant a prog:MoistPlant ;
                         prog:MoistPlant_plantId "$plantId" ;
                         prog:MoistPlant_familyName ?familyName ;
+                        prog:MoistPlant_healthState ?hs ;
                         prog:MoistPlant_pot ?pot ;
                         prog:MoistPlant_moisture ?moisture .
-                    OPTIONAL { ?plant prog:MoistPlant_healthState ?healthState }
                     OPTIONAL { ?plant prog:MoistPlant_status ?status }
                     BIND("moist" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 UNION {
                     ?plant a prog:OverwateredPlant ;
                         prog:OverwateredPlant_plantId "$plantId" ;
                         prog:OverwateredPlant_familyName ?familyName ;
+                        prog:OverwateredPlant_healthState ?hs ;
                         prog:OverwateredPlant_pot ?pot ;
                         prog:OverwateredPlant_moisture ?moisture .
-                    OPTIONAL { ?plant prog:OverwateredPlant_healthState ?healthState }
                     OPTIONAL { ?plant prog:OverwateredPlant_status ?status }
                     BIND("overwatered" AS ?moistureState)
+                    
+                    {
+                        ?hs a prog:HealthState ;
+                            prog:HealthState_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Healthy ;
+                            prog:Healthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Unhealthy ;
+                            prog:Unhealthy_name ?healthState .
+                    } UNION {
+                        ?hs a prog:Dead ;
+                            prog:Dead_name ?healthState .
+                    }
                 }
                 
                 ?pot a prog:Pot ;
@@ -217,11 +330,12 @@ class PlantService(
 
         val moisture = solution.get("?moisture").asLiteral().toString().split("^^")[0].toDouble()
 //        val healthState = if (solution.contains("?healthState")) solution.get("?healthState").asLiteral().toString() else null
-        val healthState = null
+        val healthState = solution.get("?healthState")?.asLiteral()?.toString()
         val status = if (solution.contains("?status")) solution.get("?status").asLiteral().toString() else null
         val retrievedState = solution.get("?moistureState").asLiteral().toString()
+        logger.info("Moisture state retrieved: $retrievedState")
         val moistureState = when (retrievedState) {
-            "thirst" -> PlantMoistureState.THIRSTY
+            "thirsty" -> PlantMoistureState.THIRSTY
             "moist" -> PlantMoistureState.MOIST
             "overwatered" -> PlantMoistureState.OVERWATERED
             else -> PlantMoistureState.UNKNOWN

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
@@ -60,8 +60,8 @@ class PlantService(
     fun getAllPlants(): List<Plant>? {
         logger.debug("getAllPlants: retrieving all plants")
         // Return cached plants if available
-//        val cached = componentsConfig.getPlantCache()
-//        if (cached.isNotEmpty()) return cached.values.toList()
+       val cached = componentsConfig.getPlantCache()
+       if (cached.isNotEmpty()) return cached.values.toList()
         val plants =
             """
              SELECT ?plantId ?familyName ?potId ?moisture ?healthState ?status ?moistureState WHERE {
@@ -212,7 +212,7 @@ class PlantService(
     fun getPlantByPlantId(plantId: String): Plant? {
         logger.debug("getPlantByPlantId: retrieving plant $plantId")
         // Return cached plant if present
-//        componentsConfig.getPlantById(plantId)?.let { return it }
+       componentsConfig.getPlantById(plantId)?.let { return it }
         val query = """
             SELECT DISTINCT ?familyName ?potId ?moisture ?healthState ?status ?moistureState WHERE {
                 {

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PlantService.kt
@@ -187,7 +187,7 @@ class PlantService(
             val healthState = solution.get("?healthState")?.asLiteral()?.toString()
             val status = if (solution.contains("?status")) solution.get("?status").asLiteral().toString() else null
             val retrievedState = solution.get("?moistureState").asLiteral().toString()
-            logger.info("Moisture state retrieved: $retrievedState")
+            logger.info("Moisture state  for current plant $plantId retrieved: $retrievedState")
             val moistureState = when (retrievedState) {
                 "thirsty" -> PlantMoistureState.THIRSTY
                 "moist" -> PlantMoistureState.MOIST
@@ -333,7 +333,7 @@ class PlantService(
         val healthState = solution.get("?healthState")?.asLiteral()?.toString()
         val status = if (solution.contains("?status")) solution.get("?status").asLiteral().toString() else null
         val retrievedState = solution.get("?moistureState").asLiteral().toString()
-        logger.info("Moisture state retrieved: $retrievedState")
+        logger.info("Moisture state for plant $plantId retrieved: $retrievedState")
         val moistureState = when (retrievedState) {
             "thirsty" -> PlantMoistureState.THIRSTY
             "moist" -> PlantMoistureState.MOIST

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
@@ -59,8 +59,8 @@ class PumpService(
     fun getAllPumps(): List<Pump>? {
         logger.debug("getAllPumps: retrieving all pumps")
         // Return cached pumps if available
-        val cached = componentsConfig.getPumpCache()
-        if (cached.isNotEmpty()) return cached.values.toList()
+        componentsConfig.getPumpCache()
+//        if (cached.isNotEmpty()) return cached.values.toList()
         val pumpsList = mutableListOf<Pump>()
         val pumps =
             """
@@ -145,7 +145,7 @@ class PumpService(
 
     fun getPumpByPumpId(pumpId: String): Pump? {
         logger.debug("getPumpByPumpId: retrieving pump $pumpId")
-        componentsConfig.getPumpById(pumpId)?.let { return it }
+//        componentsConfig.getPumpById(pumpId)?.let { return it }
         val pumps =
             """
              SELECT ?pumpChannel ?modelName ?lifeTime ?temperature ?pumpStatus WHERE {
@@ -285,8 +285,8 @@ class PumpService(
         }
 
         if (updatedPump.lifeTime != null) {
-            deleteClause += "OPTIONAL { ?pump ast:lifeTime ?oldLifeTime } .\n"
-            insertClause += "?pump ast:lifeTime ${updatedPump.lifeTime} .\n"
+            deleteClause += "OPTIONAL { ?pump ast:pumpLifeTime ?oldLifeTime } .\n"
+            insertClause += "?pump ast:pumpLifeTime ${updatedPump.lifeTime} .\n"
         }
 
         if (updatedPump.modelName != null) {
@@ -308,7 +308,7 @@ class PumpService(
             PREFIX ast: <$prefix>
             
             DELETE {
-                ${if (updatedPump.temperature != null) "?pump ast:temperature ?oldTemperature .\n" else ""}${if (updatedPump.lifeTime != null) "?pump ast:lifeTime ?oldLifeTime .\n" else ""}${if (updatedPump.modelName != null) "?pump ast:modelName ?oldModelName .\n" else ""}${if (updatedPump.pumpStatus != null) "?pump ast:pumpStatus ?oldStatus .\n" else ""}
+                ${if (updatedPump.temperature != null) "?pump ast:temperature ?oldTemperature .\n" else ""}${if (updatedPump.lifeTime != null) "?pump ast:pumpLifeTime ?oldLifeTime .\n" else ""}${if (updatedPump.modelName != null) "?pump ast:modelName ?oldModelName .\n" else ""}${if (updatedPump.pumpStatus != null) "?pump ast:pumpStatus ?oldStatus .\n" else ""}
             }
             INSERT {
                 $insertClause
@@ -328,7 +328,7 @@ class PumpService(
             updateProcessor.execute()
             // merge with cache if present
             val cached = componentsConfig.getPumpById(updatedPump.actuatorId)
-            val merged = if (cached == null) {
+            if (cached == null) {
                 updatedPump
             } else {
                 Pump(
@@ -340,7 +340,6 @@ class PumpService(
                     updatedPump.pumpStatus ?: cached.pumpStatus
                 )
             }
-            componentsConfig.addPumpToCache(merged)
         } catch (e: Exception) {
             return false
         }

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
@@ -72,7 +72,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:Pump_modelName ?modelName }
                     OPTIONAL { ?obj prog:Pump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:Pump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:Pump_pumpStatus ?pumpStatus }
+                    BIND ("Unknown" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:OperatingPump ;
                         prog:OperatingPump_actuatorId ?actuatorId ;
@@ -80,7 +80,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:OperatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:OperatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:OperatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:OperatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Operating" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:MaintenancePump ;
                         prog:MaintenancePump_actuatorId ?actuatorId ;
@@ -88,7 +88,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:MaintenancePump_modelName ?modelName }
                     OPTIONAL { ?obj prog:MaintenancePump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:MaintenancePump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:MaintenancePump_pumpStatus ?pumpStatus }
+                    BIND ("Maintenance" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:OverheatingPump ;
                         prog:OverheatingPump_actuatorId ?actuatorId ;
@@ -96,7 +96,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:OverheatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:OverheatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:OverheatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:OverheatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Overheating" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:UnderheatingPump ;
                         prog:UnderheatingPump_actuatorId ?actuatorId ;
@@ -104,7 +104,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:UnderheatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:UnderheatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:UnderheatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:UnderheatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Underheating" AS ?pumpStatus)
                 }
              }""".trimIndent()
 
@@ -156,7 +156,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:Pump_modelName ?modelName }
                     OPTIONAL { ?obj prog:Pump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:Pump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:Pump_pumpStatus ?pumpStatus }
+                    BIND ("Unknown" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:OperatingPump ;
                         prog:OperatingPump_actuatorId "$pumpId" ;
@@ -164,7 +164,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:OperatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:OperatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:OperatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:OperatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Operating" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:MaintenancePump ;
                         prog:MaintenancePump_actuatorId "$pumpId" ;
@@ -172,7 +172,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:MaintenancePump_modelName ?modelName }
                     OPTIONAL { ?obj prog:MaintenancePump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:MaintenancePump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:MaintenancePump_pumpStatus ?pumpStatus }
+                    BIND ("Maintenance" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:OverheatingPump ;
                         prog:OverheatingPump_actuatorId "$pumpId" ;
@@ -180,7 +180,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:OverheatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:OverheatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:OverheatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:OverheatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Overheating" AS ?pumpStatus)
                 } UNION {
                     ?obj a prog:UnderheatingPump ;
                         prog:UnderheatingPump_actuatorId "$pumpId" ;
@@ -188,7 +188,7 @@ class PumpService(
                     OPTIONAL { ?obj prog:UnderheatingPump_modelName ?modelName }
                     OPTIONAL { ?obj prog:UnderheatingPump_lifeTime ?lifeTime }
                     OPTIONAL { ?obj prog:UnderheatingPump_temperature ?temperature }
-                    OPTIONAL { ?obj prog:UnderheatingPump_pumpStatus ?pumpStatus }
+                    BIND ("Underheating" AS ?pumpStatus)
                 }
              }""".trimIndent()
 
@@ -227,7 +227,7 @@ class PumpService(
         val pumpsList = mutableListOf<Pump>()
         val pumps =
             """
-             SELECT DISTINCT ?actuatorId ?pumpChannel ?modelName ?lifeTime ?temperature ?pumpStatus WHERE {
+             SELECT DISTINCT ?actuatorId ?pumpChannel ?modelName ?lifeTime ?temperature WHERE {
                 ?obj a prog:Pump ;
                     prog:Pump_actuatorId ?actuatorId ;
                     prog:Pump_pumpChannel ?pumpChannel ;
@@ -235,7 +235,6 @@ class PumpService(
                 OPTIONAL { ?obj prog:Pump_modelName ?modelName }
                 OPTIONAL { ?obj prog:Pump_lifeTime ?lifeTime }
                 OPTIONAL { ?obj prog:Pump_temperature ?temperature }
-                OPTIONAL { ?obj prog:Pump_pumpStatus ?pumpStatus }
              }""".trimIndent()
 
         val result: ResultSet = repl.interpreter!!.query(pumps)!!

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
@@ -299,6 +299,7 @@ class PumpService(
             insertClause += "?pump ast:pumpStatus \"${updatedPump.pumpStatus}\" .\n"
         }
 
+
         if (deleteClause.isEmpty() && insertClause.isEmpty()) {
             return false // Nothing to update
         }
@@ -326,6 +327,7 @@ class PumpService(
 
         try {
             updateProcessor.execute()
+            logger.info("Successfully updated pump ${updatedPump.actuatorId} in triplestore")
             // merge with cache if present
             val cached = componentsConfig.getPumpById(updatedPump.actuatorId)
             if (cached == null) {
@@ -341,6 +343,7 @@ class PumpService(
                 )
             }
         } catch (e: Exception) {
+            logger.error("Failed to update pump ${updatedPump.actuatorId}: ${e.message}", e)
             return false
         }
 

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/PumpService.kt
@@ -145,7 +145,7 @@ class PumpService(
 
     fun getPumpByPumpId(pumpId: String): Pump? {
         logger.debug("getPumpByPumpId: retrieving pump $pumpId")
-//        componentsConfig.getPumpById(pumpId)?.let { return it }
+       componentsConfig.getPumpById(pumpId)?.let { return it }
         val pumps =
             """
              SELECT ?pumpChannel ?modelName ?lifeTime ?temperature ?pumpStatus WHERE {

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/WateringStrategyLoader.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/WateringStrategyLoader.kt
@@ -3,6 +3,8 @@ package org.smolang.greenhouse.api.service
 import com.sksamuel.hoplite.ConfigLoader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.smolang.greenhouse.api.config.MoistureDurations
+import org.smolang.greenhouse.api.config.StrategyDefinition
 import org.smolang.greenhouse.api.config.WateringStrategyConfig
 import org.smolang.greenhouse.api.model.Plant
 import org.smolang.greenhouse.api.strategy.WateringStrategy
@@ -177,6 +179,23 @@ class WateringStrategyLoader {
     }
 
     /**
+     * Get the active strategy definition
+     */
+    fun getActiveStrategyDefinition(): StrategyDefinition? {
+        return lock.read {
+            config.strategies[activeStrategyName]
+        }
+    }
+
+    /**
+     * Get watering duration for a specific plant based on the active strategy
+     */
+    fun getWateringDurationForPlant(plant: Plant): Int {
+        val strategy = getActiveStrategy()
+        return strategy.calculateWateringDuration(plant, plant.moistureState)
+    }
+
+    /**
      * Add or update a strategy in the configuration
      */
     fun addOrUpdateStrategy(
@@ -186,10 +205,10 @@ class WateringStrategyLoader {
     ): Boolean {
         return try {
             lock.write {
-                val newStrategy = org.smolang.greenhouse.api.config.StrategyDefinition(
+                val newStrategy = StrategyDefinition(
                     name = name,
                     description = description,
-                    durations = org.smolang.greenhouse.api.config.MoistureDurations(
+                    durations = MoistureDurations(
                         thirsty = thirstyDuration,
                         moist = moistDuration,
                         overwatered = overwateredDuration,
@@ -241,7 +260,7 @@ class WateringStrategyLoader {
  * Internal strategy implementation that uses configuration
  */
 private class ConfigurableWateringStrategy(
-    private val strategyDef: org.smolang.greenhouse.api.config.StrategyDefinition
+    private val strategyDef: StrategyDefinition
 ) : WateringStrategy {
 
     override fun calculateWateringDuration(plant: Plant, moistureState: PlantMoistureState): Int {

--- a/src/main/kotlin/org/smolang/greenhouse/api/service/WateringStrategyLoader.kt
+++ b/src/main/kotlin/org/smolang/greenhouse/api/service/WateringStrategyLoader.kt
@@ -3,6 +3,7 @@ package org.smolang.greenhouse.api.service
 import com.sksamuel.hoplite.ConfigLoader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.smolang.greenhouse.api.config.EnvironmentConfig
 import org.smolang.greenhouse.api.config.MoistureDurations
 import org.smolang.greenhouse.api.config.StrategyDefinition
 import org.smolang.greenhouse.api.config.WateringStrategyConfig
@@ -20,11 +21,14 @@ import kotlin.concurrent.write
  * Supports runtime reloading without application restart.
  */
 @Service
-class WateringStrategyLoader {
+class WateringStrategyLoader(
+    private val environmentConfig: EnvironmentConfig
+) {
 
     private val log: Logger = LoggerFactory.getLogger(WateringStrategyLoader::class.java.name)
-    private val configResourcePath = "/watering-strategies.yml"
-    private val configFilePath = "src/main/resources/watering-strategies.yml"
+    private val configResourcePath = environmentConfig.getOrDefault("CONFIG_RESOURCE_PATH", "/watering-strategies.yml")
+    private val configFilePath =
+        environmentConfig.getOrDefault("CONFIG_FILE_PATH", "src/main/resources/watering-strategies.yml")
     private val lock = ReentrantReadWriteLock()
 
     private var config: WateringStrategyConfig = WateringStrategyConfig()

--- a/src/main/resources/SMOL/Greenhouse_data.smol
+++ b/src/main/resources/SMOL/Greenhouse_data.smol
@@ -15,13 +15,13 @@ end
 class TemperatureHumiditySensor extends Sensor (Double temperature, Double humidity)
 end
 
-class HealthState extends Twin (context Plant plant, String name)
+class HealthState extends Twin (context Plant plant)
     Unit printInfo()
         print("Health State: " ++ this.name ++ " for plant " ++ this.plant.plantId ++ ".");
     end
 end
 
-class Healthy extends HealthState ()
+class Healthy extends HealthState (String name)
 classifies "<ast:Healthy>";
 retrieves "SELECT DISTINCT ?name WHERE {
     ast:Healthy rdfs:subClassOf ?restriction .
@@ -30,11 +30,11 @@ retrieves "SELECT DISTINCT ?name WHERE {
                  owl:hasValue ?name .
 }";
     override Unit printInfo()
-        print("Plant is healthy.");
+        print("Plant is " ++ this.name ++ ".");
     end
 end
 
-class Unhealthy extends HealthState ()
+class Unhealthy extends HealthState (String name)
 classifies "<ast:Unhealthy>";
 retrieves "SELECT DISTINCT ?name WHERE {
     ast:Unhealthy rdfs:subClassOf ?restriction .
@@ -43,11 +43,11 @@ retrieves "SELECT DISTINCT ?name WHERE {
                  owl:hasValue ?name .
 }";
     override Unit printInfo()
-        print("Plant is unhealthy.");
+        print("Plant is " ++ this.name ++ ".");
     end
 end
 
-class Dead extends HealthState ()
+class Dead extends HealthState (String name)
 classifies "<ast:Dead>";
 retrieves "SELECT DISTINCT ?name WHERE {
     ast:Dead rdfs:subClassOf ?restriction .
@@ -56,7 +56,7 @@ retrieves "SELECT DISTINCT ?name WHERE {
                  owl:hasValue ?name .
 }";
     override Unit printInfo()
-        print("Plant is dead.");
+        print("Plant is " ++ this.name ++ ".");
     end
 end
 

--- a/src/main/resources/SMOL/Greenhouse_data.smol
+++ b/src/main/resources/SMOL/Greenhouse_data.smol
@@ -171,7 +171,7 @@ classifies "<ast:ThirstyPlant>";
 end
 
 class OverwateredPlant extends Plant ()
-classifies "<ast:Overwatered>";
+classifies "<ast:OverwateredPlant>";
     Unit printInfo()
         print("Plant: " ++ this.plantId ++ " is overwatered.");
     end

--- a/src/main/resources/SMOL/Greenhouse_data.smol
+++ b/src/main/resources/SMOL/Greenhouse_data.smol
@@ -479,6 +479,11 @@ class OperatingPumpDefectLifeTime (OperatingPump obj, Int pumpLifeTimeNew) end
 class MaintenancePumpDefectLifeTime (MaintenancePump obj, Int pumpLifeTimeNew) end
 class OverheatingPumpDefectLifeTime (OverheatingPump obj, Int pumpLifeTimeNew) end
 class UnderheatingPumpDefectLifeTime (UnderheatingPump obj, Int pumpLifeTimeNew) end
+class PumpDefectModelName (Pump obj, String modelNameNew) end
+class OperatingPumpDefectModelName (OperatingPump obj, String modelNameNew) end
+class MaintenancePumpDefectModelName (MaintenancePump obj, String modelNameNew) end
+class OverheatingPumpDefectModelName (OverheatingPump obj, String modelNameNew) end
+class UnderheatingPumpDefectModelName (UnderheatingPump obj, String modelNameNew) end
 class PlantDefect (Plant obj, Double idealMoistureNew) end
 class PlantDefectStatus (Plant obj, String statusNew) end
 class PotDefectShelf (Pot obj, String shelfFloorNew) end

--- a/src/main/resources/SMOL/Greenhouse_plants.smol
+++ b/src/main/resources/SMOL/Greenhouse_plants.smol
@@ -139,6 +139,8 @@ class PlantModel extends BaseModel()
                 { ?obj a prog:ThirstyPlant . }
                 UNION
                 { ?obj a prog:MoistPlant . }
+                UNION
+                { ?obj a prog:OverwateredPlant . }
             }");
 
         if plants == null then print("ADAPT> No plants"); else

--- a/src/main/resources/SMOL/Greenhouse_pumps.smol
+++ b/src/main/resources/SMOL/Greenhouse_pumps.smol
@@ -209,6 +209,11 @@ class PumpModel extends BaseModel()
         this.adaptDefectMaintenancePumpLifeTime();
         this.adaptDefectOverheatingPumpLifeTime();
         this.adaptDefectUnderheatingPumpLifeTime();
+        this.adaptDefectPumpModelName();
+        this.adaptDefectOperatingPumpsModelName();
+        this.adaptDefectMaintenancePumpModelName();
+        this.adaptDefectOverheatingPumpModelName();
+        this.adaptDefectUnderheatingPumpModelName();
     end
 
     Unit adaptDefectPumps()
@@ -548,6 +553,176 @@ class PumpModel extends BaseModel()
 
                 rpump.obj.pumpLifeTime = rpump.pumpLifeTimeNew;
                 rpump.obj.pumpLifeTimeOut = rpump.pumpLifeTimeNew;
+                destroy(lx);
+            end
+
+            print("RECONFIG> Pump(s) changed");
+        end
+    end
+
+    Unit adaptDefectPumpModelName()
+        List<PumpDefectModelName> changedPumps = construct("
+            PREFIX ast: <http://www.smolang.org/greenhouseDT#>
+            SELECT ?obj ?modelNameNew {
+                ?obj a prog:Pump ;
+                    prog:Pump_actuatorId ?actuatorId ;
+                    prog:Pump_modelNameOut ?modelName .
+                ?y a ast:Pump ;
+                    ast:actuatorId ?actuatorId ;
+                    ast:modelName ?modelNameNew .
+                FILTER(?modelName != ?modelNameNew)
+            }");
+
+        if changedPumps != null then
+            print("RECONFIG> Changed Pump(s) detected: repairing the model");
+
+            while changedPumps != null do
+                PumpDefectModelName rpump = changedPumps.content;
+                List<PumpDefectModelName> lx = changedPumps;
+                changedPumps = changedPumps.next;
+
+                print("RECONFIG> Changed pump to adjust: " ++ rpump.obj.actuatorId);
+                print("          Old model name: " ++ rpump.obj.modelNameOut);
+                print("          New model name: " ++ rpump.modelNameNew);
+
+                rpump.obj.modelName = rpump.modelNameNew;
+                rpump.obj.modelNameOut = rpump.modelNameNew;
+                destroy(lx);
+            end
+
+            print("RECONFIG> Pump(s) changed");
+        end
+    end
+
+    Unit adaptDefectOperatingPumpsModelName()
+        List<OperatingPumpDefectModelName> changedPumps = construct("
+            PREFIX ast: <http://www.smolang.org/greenhouseDT#>
+            SELECT ?obj ?modelNameNew {
+                ?obj a prog:OperatingPump ;
+                    prog:OperatingPump_actuatorId ?actuatorId ;
+                    prog:OperatingPump_modelNameOut ?modelName .
+                ?y a ast:Pump ;
+                    ast:actuatorId ?actuatorId ;
+                    ast:modelName ?modelNameNew .
+                FILTER(?modelName != ?modelNameNew)
+            }");
+
+        if changedPumps != null then
+            print("RECONFIG> Changed Pump(s) detected: repairing the model");
+
+            while changedPumps != null do
+                OperatingPumpDefectModelName rpump = changedPumps.content;
+                List<OperatingPumpDefectModelName> lx = changedPumps;
+                changedPumps = changedPumps.next;
+
+                print("RECONFIG> Changed pump to adjust: " ++ rpump.obj.actuatorId);
+                print("          Old model name: " ++ rpump.obj.modelNameOut);
+                print("          New model name: " ++ rpump.modelNameNew);
+
+                rpump.obj.modelName = rpump.modelNameNew;
+                rpump.obj.modelNameOut = rpump.modelNameNew;
+                destroy(lx);
+            end
+
+            print("RECONFIG> Pump(s) changed");
+        end
+    end
+
+    Unit adaptDefectMaintenancePumpModelName()
+        List<MaintenancePumpDefectModelName> changedPumps = construct("
+            PREFIX ast: <http://www.smolang.org/greenhouseDT#>
+            SELECT ?obj ?modelNameNew {
+                ?obj a prog:MaintenancePump ;
+                    prog:MaintenancePump_actuatorId ?actuatorId ;
+                    prog:MaintenancePump_modelNameOut ?modelName .
+                ?y a ast:Pump ;
+                    ast:actuatorId ?actuatorId ;
+                    ast:modelName ?modelNameNew .
+                FILTER(?modelName != ?modelNameNew)
+            }");
+
+        if changedPumps != null then
+            print("RECONFIG> Changed Pump(s) detected: repairing the model");
+
+            while changedPumps != null do
+                MaintenancePumpDefectModelName rpump = changedPumps.content;
+                List<MaintenancePumpDefectModelName> lx = changedPumps;
+                changedPumps = changedPumps.next;
+
+                print("RECONFIG> Changed pump to adjust: " ++ rpump.obj.actuatorId);
+                print("          Old model name: " ++ rpump.obj.modelNameOut);
+                print("          New model name: " ++ rpump.modelNameNew);
+
+                rpump.obj.modelName = rpump.modelNameNew;
+                rpump.obj.modelNameOut = rpump.modelNameNew;
+                destroy(lx);
+            end
+
+            print("RECONFIG> Pump(s) changed");
+        end
+    end
+
+    Unit adaptDefectOverheatingPumpModelName()
+        List<OverheatingPumpDefectModelName> changedPumps = construct("
+            PREFIX ast: <http://www.smolang.org/greenhouseDT#>
+            SELECT ?obj ?modelNameNew {
+                ?obj a prog:OverheatingPump ;
+                    prog:OverheatingPump_actuatorId ?actuatorId ;
+                    prog:OverheatingPump_modelNameOut ?modelName .
+                ?y a ast:Pump ;
+                    ast:actuatorId ?actuatorId ;
+                    ast:modelName ?modelNameNew .
+                FILTER(?modelName != ?modelNameNew)
+            }");
+
+        if changedPumps != null then
+            print("RECONFIG> Changed Pump(s) detected: repairing the model");
+
+            while changedPumps != null do
+                OverheatingPumpDefectModelName rpump = changedPumps.content;
+                List<OverheatingPumpDefectModelName> lx = changedPumps;
+                changedPumps = changedPumps.next;
+
+                print("RECONFIG> Changed pump to adjust: " ++ rpump.obj.actuatorId);
+                print("          Old model name: " ++ rpump.obj.modelNameOut);
+                print("          New model name: " ++ rpump.modelNameNew);
+
+                rpump.obj.modelName = rpump.modelNameNew;
+                rpump.obj.modelNameOut = rpump.modelNameNew;
+                destroy(lx);
+            end
+
+            print("RECONFIG> Pump(s) changed");
+        end
+    end
+
+    Unit adaptDefectUnderheatingPumpModelName()
+        List<UnderheatingPumpDefectModelName> changedPumps = construct("
+            PREFIX ast: <http://www.smolang.org/greenhouseDT#>
+            SELECT ?obj ?modelNameNew {
+                ?obj a prog:UnderheatingPump ;
+                    prog:UnderheatingPump_actuatorId ?actuatorId ;
+                    prog:UnderheatingPump_modelNameOut ?modelName .
+                ?y a ast:Pump ;
+                    ast:actuatorId ?actuatorId ;
+                    ast:modelName ?modelNameNew .
+                FILTER(?modelName != ?modelNameNew)
+            }");
+
+        if changedPumps != null then
+            print("RECONFIG> Changed Pump(s) detected: repairing the model");
+
+            while changedPumps != null do
+                UnderheatingPumpDefectModelName rpump = changedPumps.content;
+                List<UnderheatingPumpDefectModelName> lx = changedPumps;
+                changedPumps = changedPumps.next;
+
+                print("RECONFIG> Changed pump to adjust: " ++ rpump.obj.actuatorId);
+                print("          Old model name: " ++ rpump.obj.modelNameOut);
+                print("          New model name: " ++ rpump.modelNameNew);
+
+                rpump.obj.modelName = rpump.modelNameNew;
+                rpump.obj.modelNameOut = rpump.modelNameNew;
                 destroy(lx);
             end
 

--- a/src/main/resources/greenhouse-2.0.ttl
+++ b/src/main/resources/greenhouse-2.0.ttl
@@ -175,6 +175,12 @@ ast:potOffset rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:string .
 
 
+###  http://www.smolang.org/greenhouseDT#powerOutput
+ast:powerOutput rdf:type owl:DatatypeProperty ;
+                rdfs:domain ast:Pump ;
+                rdfs:range xsd:integer .
+
+
 ###  http://www.smolang.org/greenhouseDT#pumpChannel
 ast:pumpChannel rdf:type owl:DatatypeProperty ;
                 rdfs:domain ast:Pump ;
@@ -1494,6 +1500,27 @@ ast:greenhouse1 rdf:type owl:NamedIndividual ,
                 ast:hasLightSensor ast:lightSensor1 ;
                 ast:hasTemperatureHumiditySensor ast:humidityTemperatureSensor1 ;
                 ast:greenhouseId "Greenhouse 1" .
+
+
+###  http://www.smolang.org/greenhouseDT#maintenanceR365
+ast:maintenanceR365 rdf:type owl:NamedIndividual ,
+                             ast:Maintenance ;
+                    ast:modelName "R365" ;
+                    ast:powerOutput 3 .
+
+
+###  http://www.smolang.org/greenhouseDT#maintenanceR385
+ast:maintenanceR385 rdf:type owl:NamedIndividual ,
+                             ast:Maintenance ;
+                    ast:modelName "R385" ;
+                    ast:powerOutput 4 .
+
+
+###  http://www.smolang.org/greenhouseDT#maintenanceWPS27
+ast:maintenanceWPS27 rdf:type owl:NamedIndividual ,
+                              ast:Maintenance ;
+                     ast:modelName "WPS27" ;
+                     ast:powerOutput 5 .
 
 
 ###  http://www.smolang.org/greenhouseDT#humidityTemperatureSensor1

--- a/src/main/resources/greenhouse-2.0.ttl
+++ b/src/main/resources/greenhouse-2.0.ttl
@@ -1583,14 +1583,16 @@ ast:plant2 rdf:type owl:NamedIndividual ,
 ast:plant3 rdf:type owl:NamedIndividual ,
                     ast:Monstera ;
            ast:isInPot ast:pot3 ;
-           ast:familyName "Araceae" .
+           ast:familyName "Araceae" ;
+           ast:plantId "3" .
 
 
 ###  http://www.smolang.org/greenhouseDT#plant4
 ast:plant4 rdf:type owl:NamedIndividual ,
                     ast:Monstera ;
            ast:isInPot ast:pot4 ;
-           ast:familyName "Ocimum basilicum" .
+           ast:familyName "Ocimum basilicum" ;
+           ast:plantId "4" .
 
 
 ###  http://www.smolang.org/greenhouseDT#pot1
@@ -1637,8 +1639,8 @@ ast:pot4 rdf:type owl:NamedIndividual ,
 ast:pump1 rdf:type owl:NamedIndividual ,
                    ast:Pump ;
           ast:actuatorId "1" ;
-          ast:pumpChannel 18 ;
           ast:modelName "R385" ;
+          ast:pumpChannel 18 ;
           ast:pumpLifeTime 0 ;
           ast:temperature "5.0"^^xsd:double .
 
@@ -1647,8 +1649,8 @@ ast:pump1 rdf:type owl:NamedIndividual ,
 ast:pump2 rdf:type owl:NamedIndividual ,
                    ast:Pump ;
           ast:actuatorId "2" ;
-          ast:pumpChannel 23 ;
           ast:modelName "WPS27" ;
+          ast:pumpChannel 23 ;
           ast:pumpLifeTime 30 ;
           ast:temperature "20.0"^^xsd:double .
 
@@ -1657,8 +1659,8 @@ ast:pump2 rdf:type owl:NamedIndividual ,
 ast:pump3 rdf:type owl:NamedIndividual ,
                    ast:Pump ;
           ast:actuatorId "3" ;
-          ast:pumpChannel 25 ;
           ast:modelName "R365" ;
+          ast:pumpChannel 25 ;
           ast:pumpLifeTime 30 ;
           ast:temperature "20.0"^^xsd:double .
 
@@ -1667,8 +1669,8 @@ ast:pump3 rdf:type owl:NamedIndividual ,
 ast:pump4 rdf:type owl:NamedIndividual ,
                    ast:Pump ;
           ast:actuatorId "4" ;
-          ast:pumpChannel 24 ;
           ast:modelName "R365" ;
+          ast:pumpChannel 24 ;
           ast:pumpLifeTime 30 ;
           ast:temperature "20.0"^^xsd:double .
 

--- a/src/main/resources/greenhouse-2.0.ttl
+++ b/src/main/resources/greenhouse-2.0.ttl
@@ -1058,6 +1058,7 @@ ast:OverwateredSchefflera rdf:type owl:Class ;
 ###  http://www.smolang.org/greenhouseDT#Plant
 ast:Plant rdf:type owl:Class ;
           owl:disjointUnionOf ( ast:MoistPlant
+                                ast:OverwateredPlant
                                 ast:ThirstyPlant
                               ) .
 

--- a/src/main/resources/greenhouse-2.0.ttl
+++ b/src/main/resources/greenhouse-2.0.ttl
@@ -1589,7 +1589,7 @@ ast:plant3 rdf:type owl:NamedIndividual ,
 
 ###  http://www.smolang.org/greenhouseDT#plant4
 ast:plant4 rdf:type owl:NamedIndividual ,
-                    ast:Monstera ;
+                    ast:Basil ;
            ast:isInPot ast:pot4 ;
            ast:familyName "Ocimum basilicum" ;
            ast:plantId "4" .


### PR DESCRIPTION
This pull request introduces several significant improvements and fixes across the API, focusing on enhanced cache management, concurrency safety, expanded endpoints for plant and pump operations, and improved data retrieval for plant health states. Below is a summary of the most important changes, grouped by theme:

**API Enhancements and New Endpoints:**

* Added a new endpoint `/api/decision/plant-strategies` in `DecisionController` to retrieve watering strategies applied to all plants, including detailed strategy information and per-plant watering duration.
* Added an endpoint in `PlantController` to update the plant model and clear the relevant cache, improving model consistency after updates.
* Improved `PumpController` endpoints to return updated `Pump` objects (instead of status strings) after updates, and to support batch updates with proper cache invalidation and refetching.

**Cache and Concurrency Improvements:**

* Introduced explicit cache clearing methods (`clearPlantCache`, `clearPumpCache`, and cache removal for individual items) in `ComponentsConfig`, and integrated these into plant and pump update endpoints to ensure data consistency.
* Added a `ReentrantLock` in `REPLConfig` to make model regeneration and reclassification operations thread-safe, preventing potential race conditions.

**Data Retrieval and Query Fixes:**

* Refined the SPARQL query in `PlantService.getAllPlants()` to more accurately retrieve the `healthState` for each plant, handling various health state types and fixing a bug in the moisture state mapping.
* 
**Configuration and Dockerfile Updates:**

* Updated the `Dockerfile` to copy new configuration files (`config_local.yml`, `watering-strategies.yml`) into the image, and switched the base image to `openjdk:24-ea-jdk-bullseye`.

These changes collectively improve the reliability, maintainability, and usability of the API, particularly around plant and pump management and strategy reporting.